### PR TITLE
add AWS tags (merge to main)

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "2.20.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:hq912gbF5V9qU6O6TpIjDecKCOpZ3s/o0HIZAIESlw8=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "2.70.0"
+  constraints = "~> 2.70"
+  hashes = [
+    "h1:6tf4jg37RrMHyVCql+fEgAFvX8JiqDognr+lk6rx7To=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "2.3.1"
+  constraints = "~> 2.3"
+  hashes = [
+    "h1:bPBDLMpQzOjKhDlP9uH2UPIz9tSjcbCtLdiJ5ASmCx4=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version     = "2.2.0"
+  constraints = "~> 2.2"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -174,3 +174,9 @@ resource "cloudflare_record" "dns" {
   type    = "CNAME"
   proxied = true
 }
+
+resource "null_resource" "force_apply" {
+  triggers = {
+    time = timestamp()
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -68,8 +68,8 @@ resource "aws_alb_listener_rule" "tg" {
  *  Create cloudwatch dashboard for service
  */
 module "ecs-service-cloudwatch-dashboard" {
-  source  = "silinternational/ecs-service-cloudwatch-dashboard/aws?ref=2.0.0"
-  version = "~> 1.0.0"
+  source  = "silinternational/ecs-service-cloudwatch-dashboard/aws"
+  version = "~> 2.0.0"
 
   cluster_name   = data.terraform_remote_state.common.outputs.ecs_cluster_name
   dashboard_name = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}"

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ resource "aws_alb_target_group" "tg" {
 /*
  * Create listener rule for hostname routing to new target group
  */
-resource "aws_lb_listener_rule" "tg" {
+resource "aws_alb_listener_rule" "tg" {
   listener_arn = data.terraform_remote_state.common.outputs.alb_https_listener_arn
   priority     = "217"
 

--- a/providers.tf
+++ b/providers.tf
@@ -18,3 +18,7 @@ provider "random" {
 provider "template" {
   version = "~> 2.2"
 }
+
+provider "null" {
+  version = "~> 3.0"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       version = "~> 2.70"


### PR DESCRIPTION
Executed the following command to move the dashboard due to the addition of `count`:

```
terraform  state mv module.ecs-service-cloudwatch-dashboard.aws_cloudwatch_dashboard.main module.ecs-service-cloudwatch-dashboard[0].aws_cloudwatch_dashboard.main
```