### PR TITLE
Latest terraform-module version and only keep 20 ECR images

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,11 +9,12 @@ locals {
  * Create ECR repo
  */
 module "ecr" {
-  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.5.0"
-  repo_name           = local.app_name_and_env
-  ecsInstanceRole_arn = data.terraform_remote_state.common.outputs.ecsInstanceRole_arn
-  ecsServiceRole_arn  = data.terraform_remote_state.common.outputs.ecsServiceRole_arn
-  cd_user_arn         = data.terraform_remote_state.common.outputs.codeship_arn
+  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.0.1"
+  repo_name             = local.app_name_and_env
+  ecsInstanceRole_arn   = data.terraform_remote_state.common.outputs.ecsInstanceRole_arn
+  ecsServiceRole_arn    = data.terraform_remote_state.common.outputs.ecsServiceRole_arn
+  cd_user_arn           = data.terraform_remote_state.common.outputs.codeship_arn
+  image_retention_count = 20
 }
 
 /*
@@ -171,7 +172,7 @@ data "template_file" "task_def_hub" {
  * Create new ecs service
  */
 module "ecs" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.5.0"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.0.1"
   cluster_id         = data.terraform_remote_state.common.outputs.ecs_cluster_id
   service_name       = var.app_name
   service_env        = local.app_env

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ module "ecr" {
   ecsServiceRole_arn    = data.terraform_remote_state.common.outputs.ecsServiceRole_arn
   cd_user_arn           = data.terraform_remote_state.common.outputs.codeship_arn
   image_retention_count = 20
-  image_retention_tags = ["latest","develop"]
+  image_retention_tags  = ["latest","develop"]
 }
 
 /*

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ module "ecr" {
   ecsServiceRole_arn    = data.terraform_remote_state.common.outputs.ecsServiceRole_arn
   cd_user_arn           = data.terraform_remote_state.common.outputs.codeship_arn
   image_retention_count = 20
+  image_retention_tags = ["latest","develop"]
 }
 
 /*

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      version = "~> 3.73"
+      version = "~> 4.0"
       source  = "hashicorp/aws"
     }
     cloudflare = {


### PR DESCRIPTION
I did tfm init -upgrade, tfm validate, tfm plan and it passed with ...

![image](https://user-images.githubusercontent.com/8058522/235696279-d0f6490d-1b44-4f27-a571-102a8d44d9af.png)
