### PR TITLE
create primary or secondary, depending on aws_region_secondary

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ data "template_file" "task_def_hub" {
     mysql_user                = local.mysql_user
     mysql_password            = module.app.database_password
     secret_salt               = random_id.ssp_secret_salt.hex
-    session_store_type        = var.session_store_type
+    session_store_type        = "sql"
     show_saml_errors          = var.show_saml_errors
     subdomain                 = var.subdomain
   }

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,6 @@ module "app" {
 
   app_env                  = local.app_env
   app_name                 = var.app_name
-  deploy_user_arn          = var.deploy_user_arn
   aws_region               = var.aws_region
   domain_name              = var.cloudflare_domain
   container_def_json       = data.template_file.task_def_hub.rendered
@@ -110,4 +109,17 @@ resource "aws_iam_user_policy" "dynamodb-logger-policy" {
       }
     ]
   })
+}
+
+/*
+ * Create ECR repo
+ */
+module "ecr" {
+  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.2.1"
+  repo_name             = local.app_name_and_env
+  ecsInstanceRole_arn   = module.app.ecsInstanceRole_arn
+  ecsServiceRole_arn    = module.app.ecsServiceRole_arn
+  cd_user_arn           = var.deploy_user_arn
+  image_retention_count = 20
+  image_retention_tags  = ["latest", "develop"]
 }

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ module "app" {
   aws_region               = var.aws_region
   domain_name              = var.cloudflare_domain
   container_def_json       = data.template_file.task_def_hub.rendered
-  create_dns_record        = var.create_dns_entry
+  create_dns_record        = var.create_dns_record
   database_name            = local.mysql_database
   database_user            = local.mysql_user
   desired_count            = var.desired_count

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,8 @@ locals {
   app_name_and_env = "${var.app_name}-${local.app_env}"
   app_env          = var.app_env
   app_environment  = var.app_environment
-  ecr_repo_url     = var.ecr_repo_url == "" ? module.ecr[0].repo_url : var.ecr_repo_url
+  create_ecr_repo  = var.ecr_repo_url == ""
+  ecr_repo_url     = local.create_ecr_repo ? module.ecr[0].repo_url : var.ecr_repo_url
   mysql_database   = "session"
   mysql_user       = "root"
   name_tag_suffix  = "${var.app_name}-${var.customer}-${local.app_environment}"
@@ -116,7 +117,7 @@ resource "aws_iam_user_policy" "dynamodb-logger-policy" {
  * Create ECR repo
  */
 module "ecr" {
-  count = var.ecr_repo_url == "" ? 1 : 0
+  count = local.create_ecr_repo ? 1 : 0
 
   source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.2.1"
   repo_name             = local.app_name_and_env

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ locals {
   app_name_and_env = "${var.app_name}-${local.app_env}"
   app_env          = var.app_env
   app_environment  = var.app_environment
+  ecr_repo_url     = var.ecr_repo_url == "" ? module.ecr[0].repo_url : var.ecr_repo_url
   mysql_database   = "session"
   mysql_user       = "root"
   name_tag_suffix  = "${var.app_name}-${var.customer}-${local.app_environment}"
@@ -59,7 +60,7 @@ data "template_file" "task_def_hub" {
     cloudwatch_log_group_name = module.app.cloudwatch_log_group_name
     cloudflare_domain         = var.cloudflare_domain
     cpu                       = var.cpu
-    docker_image              = module.app.ecr_repo_url
+    docker_image              = local.ecr_repo_url
     docker_tag                = var.docker_tag
     dynamo_access_key_id      = aws_iam_access_key.user_login_logger.id
     dynamo_secret_access_key  = aws_iam_access_key.user_login_logger.secret
@@ -115,6 +116,8 @@ resource "aws_iam_user_policy" "dynamodb-logger-policy" {
  * Create ECR repo
  */
 module "ecr" {
+  count = var.ecr_repo_url == "" ? 1 : 0
+
   source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.2.1"
   repo_name             = local.app_name_and_env
   ecsInstanceRole_arn   = module.app.ecsInstanceRole_arn

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ module "app" {
   alarm_actions_enabled    = var.alarm_actions_enabled
   ssh_key_name             = var.ssh_key_name
   aws_zones                = var.aws_zones
-  default_cert_domain_name = var.default_cert_domain_name
+  default_cert_domain_name = "*.${var.cloudflare_domain}"
 }
 
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   region     = var.aws_region
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_access_key
 
   default_tags {
     tags = {

--- a/vars.tf
+++ b/vars.tf
@@ -49,9 +49,9 @@ variable "cpu" {
   default = "128"
 }
 
-variable "create_dns_entry" {
-  description = "Set to 1 to create Cloudflare entry, 0 to not create entry"
-  default     = 1
+variable "create_dns_record" {
+  description = "Set to false to skip creation of a Cloudflare record"
+  default     = true
 }
 
 variable "desired_count" {

--- a/vars.tf
+++ b/vars.tf
@@ -42,6 +42,11 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "aws_region_secondary" {
+  description = "AWS region in which to create replica resources. If omitted, no replicas are created."
+  default     = ""
+}
+
 variable "aws_secret_access_key" {
 }
 
@@ -71,11 +76,6 @@ variable "desired_count" {
 variable "docker_tag" {
   description = "Docker tag to use in the task definition. Must match the tag name defined in the instance repo's `push_latest` step."
   default     = "latest"
-}
-
-variable "ecr_repo_url" {
-  description = "ECR repository URL. If not specified, a new repository will be created."
-  default     = ""
 }
 
 variable "help_center_url" {

--- a/vars.tf
+++ b/vars.tf
@@ -76,30 +76,7 @@ variable "idp_display_name" {
 }
 
 variable "idp_name" {
-}
-
-variable "memcache_az_mode" {
-  type    = string
-  default = "cross-az"
-}
-
-variable "memcache_node_type" {
-  default = "cache.t2.micro"
-}
-
-variable "memcache_num_cache_nodes" {
-  type    = string
-  default = 2
-}
-
-variable "memcache_parameter_group_name" {
-  type    = string
-  default = "default.memcached1.5"
-}
-
-variable "memcache_port" {
-  type    = string
-  default = "11211"
+  description = ""
 }
 
 variable "memory" {

--- a/vars.tf
+++ b/vars.tf
@@ -154,12 +154,3 @@ variable "aws_zones" {
   type    = list(string)
   default = ["us-east-1c", "us-east-1d", "us-east-1e"]
 }
-
-/*
- * ALB configuration
- */
-
-variable "default_cert_domain_name" {
-  type        = string
-  description = "Default/primary certificate domain name"
-}

--- a/vars.tf
+++ b/vars.tf
@@ -102,11 +102,6 @@ variable "memory" {
   default = "128"
 }
 
-variable "session_store_type" {
-  description = "type of storage to use for sessions, can be \"memcache\" or \"sql\""
-  default     = "sql"
-}
-
 variable "show_saml_errors" {
   default = "false"
 }

--- a/vars.tf
+++ b/vars.tf
@@ -26,14 +26,15 @@ variable "deploy_user_arn" {
   type        = string
 }
 
-variable "aws_access_key" {
+variable "aws_access_key_id" {
+  description = ""
 }
 
 variable "aws_region" {
   default = "us-east-1"
 }
 
-variable "aws_secret_key" {
+variable "aws_secret_access_key" {
 }
 
 variable "cloudflare_domain" {

--- a/vars.tf
+++ b/vars.tf
@@ -1,24 +1,31 @@
 variable "admin_email" {
+  description = "SAML technical contact email. This information will be available in the generated metadata."
+  type        = string
 }
 
 variable "admin_name" {
+  description = "SAML technical contact name. This information will be available in the generated metadata."
+  type        = string
 }
 
 variable "analytics_id" {
+  description = "Google Analytics measurement ID"
+  type        = string
 }
 
 variable "app_name" {
-  default = "idp-hub"
+  description = "A name to be used, combined with \"app_env\", for naming resources. Should be unique in the AWS account."
+  default     = "idp-hub"
 }
 
 variable "app_env" {
+  description = "The abbreviated version of the environment used for naming resources, typically either stg or prod"
   type        = string
-  description = "the abbreviated version of the environment used for naming resources, typically either stg or prod"
 }
 
 variable "app_environment" {
-  type        = string
   description = "the full, unabbreviated environment used for AWS tags, typically either staging or production"
+  type        = string
 }
 
 variable "deploy_user_arn" {
@@ -31,22 +38,24 @@ variable "aws_access_key_id" {
 }
 
 variable "aws_region" {
-  default = "us-east-1"
+  description = "AWS region in which to create all resources"
+  default     = "us-east-1"
 }
 
 variable "aws_secret_access_key" {
 }
 
 variable "cloudflare_domain" {
+  description = "The domain name on which to host the app. Combined with \"subdomain\" to create an ALB listener rule. Also used for the optional DNS record."
 }
 
 variable "cloudflare_token" {
   description = "The Cloudflare API token with permissions on `cloudflare_domain`."
-  default     = ""
 }
 
 variable "cpu" {
-  default = "128"
+  description = "The hard limit of CPU units to present for the task, expressed as an integer using CPU units, e.g. 512 = 0.5 vCPU"
+  default     = "128"
 }
 
 variable "create_dns_record" {
@@ -55,24 +64,28 @@ variable "create_dns_record" {
 }
 
 variable "desired_count" {
-  default = 2
+  description = "Number of tasks to place and keep running."
+  default     = 2
 }
 
 variable "docker_tag" {
-  default = "latest"
+  description = "Docker tag to use in the task definition. Must match the tag name defined in the instance repo's `push_latest` step."
+  default     = "latest"
 }
 
 variable "ecr_repo_url" {
   description = "ECR repository URL. If not specified, a new repository will be created."
+  default     = ""
 }
 
 variable "help_center_url" {
-  description = "Appears at the top of the IDP selection page"
+  description = "The URL for the \"Help\" link at the top of the IDP selection page"
   type        = string
   default     = ""
 }
 
 variable "idp_display_name" {
+  description = ""
 }
 
 variable "idp_name" {
@@ -80,14 +93,17 @@ variable "idp_name" {
 }
 
 variable "memory" {
-  default = "128"
+  description = "The hard limit of memory (in MiB) to present to the task, expressed as an integer"
+  default     = "128"
 }
 
 variable "show_saml_errors" {
-  default = "false"
+  description = "Used for SimpleSAMLphp `showerrors` config option. When enabled, all error messages and stack traces will be output to the browser."
+  default     = "false"
 }
 
 variable "subdomain" {
+  description = "The subdomain on which to host the app. Combined with \"domain_name\" to create an ALB listener rule. Also used for the optional DNS record."
 }
 
 variable "customer" {
@@ -107,20 +123,23 @@ variable "create_dashboard" {
  */
 
 variable "asg_min_size" {
-  default = 1
+  description = "minimum number of EC2 instances in the autoscaling group"
+  default     = 2
 }
 
 variable "asg_max_size" {
-  default = 5
+  description = "maximum number of EC2 instances in the autoscaling group"
+  default     = 2
 }
 
 variable "alarm_actions_enabled" {
-  default     = false
   description = "True/false enable auto-scaling events and actions"
+  default     = false
 }
 
 variable "ssh_key_name" {
-  default = ""
+  description = "Name of SSH key pair to use as default (ec2-user) user key. Set in the launch template"
+  default     = ""
 }
 
 /*
@@ -128,6 +147,7 @@ variable "ssh_key_name" {
  */
 
 variable "aws_zones" {
-  type    = list(string)
-  default = ["us-east-1c", "us-east-1d", "us-east-1e"]
+  description = "The VPC availability zone list"
+  type        = list(string)
+  default     = ["us-east-1c", "us-east-1d", "us-east-1e"]
 }

--- a/vars.tf
+++ b/vars.tf
@@ -62,6 +62,10 @@ variable "docker_tag" {
   default = "latest"
 }
 
+variable "ecr_repo_url" {
+  description = "ECR repository URL. If not specified, a new repository will be created."
+}
+
 variable "help_center_url" {
   description = "Appears at the top of the IDP selection page"
   type        = string


### PR DESCRIPTION
### Changed
- Use `var.cloudflare_domain` to calculate the default_cert_domain_name
- Use the full names of the aws key variables
- Change `create_dns_entry` to `create_dns_record` and make it a bool
- Bring the ECR repo into this module
- Hardcode the `session_store_type` since the actual storage is not that easily changed
- Remove memcache variables
- Add variable descriptions
- Create an ECR replication configuration if running on the primary region (`aws_secondary_region != ""`)
