### PR TITLE
IDP-527 - manage the logger DynamoDB table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# idp-hub-terraform
+
+This is a Terraform root block defining a SimpleSAMLphp "hub". It is based on
+[ssp-base](https://github.com/silinternational/ssp-base) which utilizes several custom SimpleSAMLphp
+modules, providing a menu of Identity Provider (IdP) choices for a user to choose from. The hub acts
+as an IdP to a number of Service Providers (SP) and as a SP to the chosen IDP. 

--- a/main.tf
+++ b/main.tf
@@ -159,13 +159,6 @@ module "rds" {
   allocated_storage = 20 // 20 gibibyte
   instance_class    = "db.t3.micro"
   multi_az          = true
-  tags = {
-    managed_by        = "terraform"
-    workspace         = terraform.workspace
-    itse_app_customer = var.customer
-    itse_app_env      = local.app_environment
-    itse_app_name     = "idp-hub"
-  }
 }
 
 /*

--- a/main.tf
+++ b/main.tf
@@ -292,3 +292,24 @@ data "cloudflare_zones" "domain" {
     status      = "active"
   }
 }
+
+locals {
+  table_names = {
+    stg  = "sildisco_dev_user-log"
+    prod = "sildisco_prod_user-log"
+  }
+}
+
+resource "aws_dynamodb_table" "logger" {
+  name         = local.table_names[local.app_env]
+  billing_mode = "PAY_PER_REQUEST"
+  attribute {
+    name = "ID"
+    type = "S"
+  }
+  hash_key = "ID"
+  ttl {
+    enabled        = true
+    attribute_name = "ExpiresAt"
+  }
+}

--- a/vars.tf
+++ b/vars.tf
@@ -14,6 +14,7 @@ variable "app_name" {
 }
 
 variable "aws_access_key" {
+  default = null
 }
 
 variable "aws_region" {
@@ -21,6 +22,7 @@ variable "aws_region" {
 }
 
 variable "aws_secret_key" {
+  default = null
 }
 
 variable "cloudflare_domain" {
@@ -28,7 +30,7 @@ variable "cloudflare_domain" {
 
 variable "cloudflare_token" {
   description = "The Cloudflare API token with permissions on `cloudflare_domain`."
-  default     = ""
+  default     = null
 }
 
 variable "cpu" {


### PR DESCRIPTION
### Added
- Added a resource to manage the DynamoDB table for sildisco logging.
- Created a README.md file.
- Added default values for `aws_access_key` and `aws_secret_key` so they can be provided in environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).

### Changed
- Changed the default value for `cloudflare_token` so it can be provided in an environment variable (`CLOUDFLARE_TOKEN`).

### Removed
- Removed duplicate tagging on the RDS database. It made Terraform want to re-add the tags on every plan.

Youtrack Issue [IDP-527](https://itse.youtrack.cloud/issue/IDP-527)