### PR TITLE
Release 2.1.0 - manage DynamoDB table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# idp-hub-terraform
+
+This is a Terraform root block defining a SimpleSAMLphp "hub". It is based on
+[ssp-base](https://github.com/silinternational/ssp-base) which utilizes several custom SimpleSAMLphp
+modules, providing a menu of Identity Provider (IdP) choices for a user to choose from. The hub acts
+as an IdP to a number of Service Providers (SP) and as a SP to the chosen IDP. 

--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,8 @@ module "ecs-service-cloudwatch-dashboard" {
  * Create Elasticache subnet group
  */
 resource "aws_elasticache_subnet_group" "memcache_subnet_group" {
-  count = var.session_store_type == "memcache" ? 1 : 0
+  count = 1
+  #  count = var.session_store_type == "memcache" ? 1 : 0
 
   name       = local.app_name_and_env
   subnet_ids = data.terraform_remote_state.common.outputs.private_subnet_ids
@@ -112,7 +113,8 @@ resource "aws_elasticache_subnet_group" "memcache_subnet_group" {
  * Create Elasticache cluster
  */
 resource "aws_elasticache_cluster" "memcache" {
-  count = var.session_store_type == "memcache" ? 1 : 0
+  count = 1
+  #  count = var.session_store_type == "memcache" ? 1 : 0
 
   cluster_id           = local.app_name_and_env
   engine               = "memcached"

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,8 @@ resource "random_password" "db_root" {
   count = 1
   #  count = var.session_store_type == "sql" ? 1 : 0
 
-  length = 16
+  length           = 16
+  override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
 /*

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,8 @@ resource "aws_elasticache_cluster" "memcache" {
  * Create RDS root password
  */
 resource "random_password" "db_root" {
-  count = var.session_store_type == "sql" ? 1 : 0
+  count = 1
+  #  count = var.session_store_type == "sql" ? 1 : 0
 
   length = 16
 }

--- a/main.tf
+++ b/main.tf
@@ -159,13 +159,6 @@ module "rds" {
   allocated_storage = 20 // 20 gibibyte
   instance_class    = "db.t3.micro"
   multi_az          = true
-  tags = {
-    managed_by        = "terraform"
-    workspace         = terraform.workspace
-    itse_app_customer = var.customer
-    itse_app_env      = local.app_environment
-    itse_app_name     = "idp-hub"
-  }
 }
 
 /*
@@ -290,5 +283,26 @@ data "cloudflare_zones" "domain" {
     name        = var.cloudflare_domain
     lookup_type = "exact"
     status      = "active"
+  }
+}
+
+locals {
+  table_names = {
+    stg  = "sildisco_dev_user-log"
+    prod = "sildisco_prod_user-log"
+  }
+}
+
+resource "aws_dynamodb_table" "logger" {
+  name         = local.table_names[local.app_env]
+  billing_mode = "PAY_PER_REQUEST"
+  attribute {
+    name = "ID"
+    type = "S"
+  }
+  hash_key = "ID"
+  ttl {
+    enabled        = true
+    attribute_name = "ExpiresAt"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -98,8 +98,7 @@ module "ecs-service-cloudwatch-dashboard" {
  * Create Elasticache subnet group
  */
 resource "aws_elasticache_subnet_group" "memcache_subnet_group" {
-  count = 1
-  #  count = var.session_store_type == "memcache" ? 1 : 0
+  count = var.session_store_type == "memcache" ? 1 : 0
 
   name       = local.app_name_and_env
   subnet_ids = data.terraform_remote_state.common.outputs.private_subnet_ids
@@ -113,8 +112,7 @@ resource "aws_elasticache_subnet_group" "memcache_subnet_group" {
  * Create Elasticache cluster
  */
 resource "aws_elasticache_cluster" "memcache" {
-  count = 1
-  #  count = var.session_store_type == "memcache" ? 1 : 0
+  count = var.session_store_type == "memcache" ? 1 : 0
 
   cluster_id           = local.app_name_and_env
   engine               = "memcached"
@@ -136,8 +134,7 @@ resource "aws_elasticache_cluster" "memcache" {
  * Create RDS root password
  */
 resource "random_password" "db_root" {
-  count = 1
-  #  count = var.session_store_type == "sql" ? 1 : 0
+  count = var.session_store_type == "sql" ? 1 : 0
 
   length           = 16
   override_special = "!#$%&*()-_=+[]{}<>:?"
@@ -147,8 +144,7 @@ resource "random_password" "db_root" {
  * Create RDS database for session store, if session_store_type is "sql"
  */
 module "rds" {
-  count = 1
-  #  count = var.session_store_type == "sql" ? 1 : 0
+  count = var.session_store_type == "sql" ? 1 : 0
 
   source = "github.com/silinternational/terraform-modules//aws/rds/mariadb?ref=8.0.1"
 

--- a/vars.tf
+++ b/vars.tf
@@ -14,6 +14,7 @@ variable "app_name" {
 }
 
 variable "aws_access_key" {
+  default = null
 }
 
 variable "aws_region" {
@@ -21,6 +22,7 @@ variable "aws_region" {
 }
 
 variable "aws_secret_key" {
+  default = null
 }
 
 variable "cloudflare_domain" {
@@ -28,7 +30,7 @@ variable "cloudflare_domain" {
 
 variable "cloudflare_token" {
   description = "The Cloudflare API token with permissions on `cloudflare_domain`."
-  default     = ""
+  default     = null
 }
 
 variable "cpu" {


### PR DESCRIPTION
## Changelog

### Added
- Added a resource to manage the DynamoDB table for sildisco logging.
- Created a README.md file.
- Added default values for `aws_access_key` and `aws_secret_key` so they can be provided in environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).

### Changed
- Changed the default value for `cloudflare_token` so it can be provided in an environment variable (`CLOUDFLARE_TOKEN`).

### Removed
- Removed duplicate tagging on the RDS database. It made Terraform want to re-add the tags on every plan.

## Notes

To import the existing table into the state on Terraform Cloud, run this command:
```
op run --env-file=.env terraform import aws_dynamodb_table.logger sildisco_prod_user-log
```

This assumes the presence of an `.env` file containing 1Password [secret references](https://developer.1password.com/docs/cli/secrets-reference-syntax/):
```env
AWS_ACCESS_KEY_ID="op://vault/item/section/field"
AWS_SECRET_ACCESS_KEY="op://vault/item/section/field"
CLOUDFLARE_API_TOKEN="op://vault/item/section/field"
TF_VAR_cloudflare_domain=example.com
```

_Substitute the correct information in the above .env template_

Youtrack Issue [IDP-527](https://itse.youtrack.cloud/issue/IDP-527)