### PR TITLE
add instance_type variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ module "app" {
   create_dashboard         = var.create_dashboard
   asg_min_size             = var.asg_min_size
   asg_max_size             = var.asg_max_size
+  instance_type            = var.instance_type
   alarm_actions_enabled    = var.alarm_actions_enabled
   ssh_key_name             = var.ssh_key_name
   aws_zones                = var.aws_zones

--- a/vars.tf
+++ b/vars.tf
@@ -180,6 +180,12 @@ variable "desired_count" {
   default     = 2
 }
 
+variable "instance_type" {
+  description = "See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#AvailableInstanceTypes"
+  default     = "t2.micro"
+  type        = string
+}
+
 variable "ssh_key_name" {
   description = "Name of SSH key pair to use as default (ec2-user) user key. Set in the launch template"
   type        = string


### PR DESCRIPTION
### Added
- New variable `instance_type` to specify the EC2 instance type, e.g. "t2-micro".