### PR TITLE
Don't create a second user and allow DNS overwrite

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ module "app" {
   domain_name              = var.cloudflare_domain
   container_def_json       = data.template_file.task_def_hub.rendered
   create_dns_record        = var.create_dns_record
+  dns_allow_overwrite      = local.is_multiregion
   create_cd_user           = local.create_cd_user
   database_name            = local.mysql_database
   database_user            = local.mysql_user

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ locals {
   ecr_repo_name    = local.app_name_and_env
   is_multiregion   = var.aws_region_secondary != ""
   is_primary       = local.is_multiregion && var.aws_region != var.aws_region_secondary
+  create_cd_user   = !local.is_multiregion || local.is_primary
   mysql_database   = "session"
   mysql_user       = "root"
   name_tag_suffix  = "${var.app_name}-${var.customer}-${local.app_environment}"
@@ -18,7 +19,7 @@ module "app" {
   domain_name              = var.cloudflare_domain
   container_def_json       = data.template_file.task_def_hub.rendered
   create_dns_record        = var.create_dns_record
-  create_cd_user           = !local.is_multiregion || local.is_primary
+  create_cd_user           = local.create_cd_user
   database_name            = local.mysql_database
   database_user            = local.mysql_user
   desired_count            = var.desired_count
@@ -123,7 +124,7 @@ module "ecr" {
   repo_name             = local.ecr_repo_name
   ecsInstanceRole_arn   = module.app.ecsInstanceRole_arn
   ecsServiceRole_arn    = module.app.ecsServiceRole_arn
-  cd_user_arn           = module.app.cd_user_arn
+  cd_user_arn           = local.create_cd_user ? module.app.cd_user_arn : var.cd_user_arn
   image_retention_count = 20
   image_retention_tags  = ["latest", "develop"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,6 +20,10 @@ output "cd_user_secret_access_key_id" {
   sensitive = true
 }
 
+output "cd_user_arn" {
+  value = local.create_cd_user ? module.app.cd_user_arn : var.cd_user_arn
+}
+
 output "user_log_table" {
   value = aws_dynamodb_table.logger.name
 }

--- a/vars.tf
+++ b/vars.tf
@@ -51,7 +51,7 @@ variable "aws_region" {
 }
 
 variable "aws_region_secondary" {
-  description = "AWS region in which to create replica resources. If omitted, no replicas are created and this hub is configured to be the secondary."
+  description = "AWS region in which to create ECR replicas. Must be specified in both the primary and secondary hub workspaces. Leave empty for a single-region setup."
   type        = string
   default     = ""
 }

--- a/vars.tf
+++ b/vars.tf
@@ -56,6 +56,12 @@ variable "aws_region_secondary" {
   default     = ""
 }
 
+variable "cd_user_arn" {
+  description = "ARN of the Continuous Deployment (CD) user created by the primary hub in a multiregion configuration. Ignored in a single-region configuration."
+  type        = string
+  default     = ""
+}
+
 variable "docker_tag" {
   description = "Docker tag to use in the task definition. Must match the tag name defined in the instance repo's `push_latest` step."
   type        = string


### PR DESCRIPTION
### Added
- New variable `cd_user_arn` to specify the CD user to which to grant permissions on the ECR repository in the secondary region. This would be set to the user created by the primary hub's Terraform workspace.

### Fixed
- Don't try to create another CD user in the secondary region. There was a naming conflict and only one is really needed.
- Set `dns_allow_overwrite` to `true` if running in multiregion mode.