### PR TITLE
New CA Cert for RDS; ASG Name tag; ENABLE_DEBUG option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,7 @@ locals {
     docker_tag                = var.docker_tag
     dynamo_access_key_id      = aws_iam_access_key.user_login_logger.id
     dynamo_secret_access_key  = aws_iam_access_key.user_login_logger.secret
+    enable_debug              = var.enable_debug
     help_center_url           = var.help_center_url
     idp_display_name          = var.idp_display_name
     idp_name                  = var.idp_name

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ locals {
 
 module "app" {
   source  = "silinternational/ecs-app/aws"
-  version = "0.4.0"
+  version = "0.5.0"
 
   app_env                  = local.app_env
   app_name                 = var.app_name
@@ -35,6 +35,7 @@ module "app" {
   default_cert_domain_name = "*.${var.cloudflare_domain}"
   create_adminer           = true
   enable_adminer           = var.enable_adminer
+  rds_ca_cert_identifier   = "rds-ca-rsa2048-g1"
 }
 
 
@@ -153,7 +154,7 @@ resource "aws_iam_user_policy" "dynamodb-logger-policy" {
  * Create ECR repo
  */
 module "ecr" {
-  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.2.1"
+  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.8.0"
   repo_name             = local.ecr_repo_name
   ecsInstanceRole_arn   = module.app.ecsInstanceRole_arn
   ecsServiceRole_arn    = module.app.ecsServiceRole_arn

--- a/task-def-hub.json
+++ b/task-def-hub.json
@@ -96,6 +96,10 @@
       {
         "name": "SHOW_SAML_ERRORS",
         "value": "${show_saml_errors}"
+      },
+      {
+        "name": "ENABLE_DEBUG",
+        "value": "${enable_debug}"
       }
     ],
     "ulimits": null,

--- a/vars.tf
+++ b/vars.tf
@@ -94,6 +94,12 @@ variable "cpu" {
   default     = "128"
 }
 
+variable "enable_debug" {
+  description = "Enables debug for SimpleSAMLphp 'saml' and 'validatexml' modes. CAUTION: may log decrypted SAML messages."
+  type        = string
+  default     = "false"
+}
+
 variable "idp_display_name" {
   description = "The name of the hub as presented to the end user."
   type        = string


### PR DESCRIPTION
### Changed
- Update module dependencies
  - Latest version of ecs-app module adds a Name tag to the ASG, and by extension, created EC2 instances. ([IDP-851](https://itse.youtrack.cloud/issue/IDP-851))
- Changed RDS CA Certificate to `rds-ca-rsa2048-g1`

### Added
- New `ENABLE_DEBUG` variable in task definition set by `enable_debug` input variable