### PR TITLE
Release v5.6.0 - Add `asg_additional_user_data` variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ locals {
 
 module "app" {
   source  = "silinternational/ecs-app/aws"
-  version = "~> 0.10.4"
+  version = "~> 0.10.5"
 
   app_env                  = local.app_env
   app_name                 = var.app_name
@@ -34,6 +34,7 @@ module "app" {
   desired_count            = var.desired_count
   subdomain                = var.subdomain
   create_dashboard         = var.create_dashboard
+  asg_additional_user_data = var.asg_additional_user_data
   asg_min_size             = var.asg_min_size
   asg_max_size             = var.asg_max_size
   instance_type            = var.instance_type

--- a/vars.tf
+++ b/vars.tf
@@ -162,6 +162,12 @@ variable "subdomain" {
  * ECS and ASG configuration
  */
 
+variable "asg_additional_user_data" {
+  description = "Bash code to append to the default EC2 user_data."
+  type        = string
+  default     = ""
+}
+
 variable "asg_min_size" {
   description = "minimum number of EC2 instances in the autoscaling group"
   type        = number


### PR DESCRIPTION
[IDP-1631](https://support.gtis.sil.org/issue/IDP-1631)

---

### Added
- Add `asg_additional_user_data` variable
  * This lets us provide additional content for the EC2 user data script (in the Launch Template), used by the Auto-Scaling Group for this app's ECS Cluster.