### PR TITLE
Release 6.0.0 -- use CD role in place of the CD user for GitHub deployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,14 +21,16 @@ locals {
 
 module "app" {
   source  = "sil-org/ecs-app/aws"
-  version = "~> 0.12.0"
+  version = "~> 0.13.0"
 
   app_env                      = local.app_env
   app_name                     = var.app_name
   domain_name                  = var.cloudflare_domain
   container_def_json           = local.task_def_hub
   create_dns_record            = false
-  create_cd_user               = true
+  create_cd_role               = true
+  github_oidc_provider_arn     = var.github_oidc_provider_arn
+  github_repository            = var.github_repository
   database_deletion_protection = true
   database_name                = local.mysql_database
   database_user                = local.mysql_user
@@ -194,7 +196,7 @@ module "ecr" {
   repo_name             = local.ecr_repo_name
   ecsInstanceRole_arn   = module.app.ecsInstanceRole_arn
   ecsServiceRole_arn    = module.app.ecsServiceRole_arn
-  cd_user_arn           = module.app.cd_user_arn
+  cd_user_arn           = module.app.cd_role_arn
   image_retention_count = 20
   image_retention_tags  = ["latest"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,24 @@ variable "docker_tag" {
   default     = "latest"
 }
 
+variable "github_oidc_provider_arn" {
+  description = <<-EOT
+    ARN of the OIDC provider for GitHub in AWS IAM, used for GitHub Actions to authenticate to AWS. The provider
+    can be created in Terraform using the `aws_iam_openid_connect_provider` resource. Specify the URL as
+    "https://token.actions.githubusercontent.com" and the client_id_list as ["sts.amazonaws.com"].
+    This is required if `create_cd_role` is true.
+  EOT
+  type        = string
+}
+
+variable "github_repository" {
+  description = <<-EOT
+    GitHub repository that should be granted access to the OIDC provider for GitHub. Format should be 'owner/repo'.
+    This is required if `create_cd_role` is true.
+  EOT
+  type        = string
+}
+
 variable "require_secure_transport" {
   description = "Set to true to require SSL for database connection."
   type        = bool


### PR DESCRIPTION
[IDP-1926](https://support.gtis.sil.org/issue/IDP-1926) convert IdP to use a role for deployment

Used in this change: https://github.com/sil-org/ssp-hub-staging/pull/183

---

### Changed (Breaking)
- Use an IAM Role for deployment instead of a user and key.
